### PR TITLE
(#1) chore: add vercel and env local to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 dist
+.vercel
+.env*.local


### PR DESCRIPTION
## Summary
- Add `.vercel` to `.gitignore` to exclude Vercel deployment artifacts
- Add `.env*.local` to `.gitignore` to exclude local environment files

Closes #1

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>